### PR TITLE
chore(lib): Build the lib on prepublish/postinstall

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015"],
+  "plugins": []
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "rm -rf lib",
     "lint": "eslint .",
     "prepublish": "npm run build",
-    "postinstall": "npm run build",
+    "postinstall": "npm run build"
   },
   "keywords": [
     "es6",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "babel src --out-dir lib --copy-files --presets es2015",
     "test": "node test",
     "clean": "rm -rf lib",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "prepublish": "npm run build",
+    "postinstall": "npm run build",
   },
   "keywords": [
     "es6",


### PR DESCRIPTION
The lib folder is not included in the folder when installing.